### PR TITLE
max-width 아이폰 13/14 크기에 맞게 조정

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@ body {
 #root {
     padding: 0px 20px;
     background-color: #f1f3f5;
-    max-width: 600px;
+    max-width: 390px;
     width: 100%;
     margin: 0 auto;
     min-height: 100vh;


### PR DESCRIPTION
기본 화면 max-width를 아이폰 13/14 크기에 맞게 390px로 조정